### PR TITLE
Part 4 - negotiate order

### DIFF
--- a/Orders.cpp
+++ b/Orders.cpp
@@ -650,10 +650,19 @@ ostream& operator<<(ostream& os, const Negotiate& negotiate) {
     return os;
 }
 
+/**
+ * Checks that:
+ * 1) the target is not the player issuing the order
+ * TODO: ensure that the negotiate order can only be created by playing the diplomacy card
+ * @return whether the order is valid or not
+ */
 bool Negotiate::validate()  {
-    cout << "negotiate order validated\n";
+    if (this->targetPlayer->getName() == this->issuer->getName()) {
+        // player can't negotiate with itself
+        return false;
+    }
 
-    return true; // logic to be implemented in later assignments
+    return true;
 }
 
 void Negotiate::execute() {

--- a/Orders.cpp
+++ b/Orders.cpp
@@ -626,18 +626,26 @@ void Airlift::setAirliftArmies(int airliftArmies) {
 
 // Negotiate
 Negotiate::Negotiate():Order() {}
-Negotiate::Negotiate(const Negotiate& negotiate):Order() {} // no members to copy for now
+Negotiate::Negotiate(shared_ptr<Player> &issuer, shared_ptr<Player> &targetPlayer):
+    issuer(issuer), targetPlayer(targetPlayer) {}
+Negotiate::Negotiate(const Negotiate& negotiate):Order(negotiate) {
+    this->issuer = negotiate.issuer;
+    this->targetPlayer = negotiate.targetPlayer;
+}
 Negotiate& Negotiate::operator=(const Negotiate& negotiate) {
     if (this == &negotiate) {
         return *this;
     } else {
-        // no members to copy for now
+        this->issuer = negotiate.issuer;
+        this->targetPlayer = negotiate.targetPlayer;
+
         return *this;
     }
 }
 ostream& operator<<(ostream& os, const Negotiate& negotiate) {
     os << static_cast<const Order&>(negotiate);
-    // no specific member info to return for now
+    os << " - issuer: " << negotiate.getIssuer()->getName();
+    os << " - targetPlayer: " << negotiate.getTargetPlayer()->getName();
 
     return os;
 }
@@ -651,6 +659,22 @@ bool Negotiate::validate()  {
 void Negotiate::execute() {
     // logic to be implemented in later assignments
     cout << "negotiate order executed\n";
+}
+
+const shared_ptr<Player> &Negotiate::getIssuer() const {
+    return issuer;
+}
+
+void Negotiate::setIssuer(const shared_ptr<Player> &issuer) {
+    Negotiate::issuer = issuer;
+}
+
+const shared_ptr<Player> &Negotiate::getTargetPlayer() const {
+    return targetPlayer;
+}
+
+void Negotiate::setTargetPlayer(const shared_ptr<Player> &targetPlayer) {
+    Negotiate::targetPlayer = targetPlayer;
 }
 
 // OrdersList

--- a/Orders.cpp
+++ b/Orders.cpp
@@ -45,11 +45,10 @@ void Order::setNextId(int nextId) {
 // execute() for every subclass
 
 // Deploy
-Deploy::Deploy():Order() {}
 Deploy::Deploy(const shared_ptr<Player>& player,
                const shared_ptr<Territory>& targetTerritory,
                const int deployedArmies):
-    player(player), targetTerritory(targetTerritory), deployedArmies(deployedArmies) {}
+    Order(), player(player), targetTerritory(targetTerritory), deployedArmies(deployedArmies) {}
 Deploy::Deploy(const Deploy& deploy):Order(deploy) {
     this->player = deploy.player;
     this->targetTerritory = deploy.targetTerritory;
@@ -135,11 +134,11 @@ void Deploy::setDeployedArmies(int deployedArmies) {
 }
 
 // Advance
-Advance::Advance():Order() {}
 Advance::Advance(const shared_ptr<Player>& player,
                  const shared_ptr<Territory>& sourceTerritory,
                  const shared_ptr<Territory>& targetTerritory,
                  int advanceArmies):
+                 Order(),
                  player(player),
                  sourceTerritory(sourceTerritory), targetTerritory(targetTerritory),
                  advanceArmies(advanceArmies) {}
@@ -295,6 +294,12 @@ void Advance::attack() {
         auto newArmyCountPtr = make_unique<int>(defendingArmies);
         targetTerritory->setArmyCnt(newArmyCountPtr);
     }
+
+    // TODO: after every turn
+    //  1) update army count
+    //  2) update reinforcement pool
+    //  3) update territories
+    //  4) clear negotiated players
 }
 
 // getters and setters
@@ -331,10 +336,9 @@ void Advance::setAdvanceArmies(int advanceArmies) {
 }
 
 // Bomb
-Bomb::Bomb():Order() {}
 Bomb::Bomb(const shared_ptr<Player>& player,
            const shared_ptr<Territory>& targetTerritory):
-           player(player), targetTerritory(targetTerritory) {}
+           Order(), player(player), targetTerritory(targetTerritory) {}
 Bomb::Bomb(const Bomb& bomb):Order(bomb) {
     this->player = bomb.player;
     this->targetTerritory = bomb.targetTerritory;
@@ -419,11 +423,10 @@ void Bomb::setTargetTerritory(const shared_ptr<Territory> &targetTerritory) {
 }
 
 // Blockade
-Blockade::Blockade():Order() {}
 Blockade::Blockade(const shared_ptr<Player>& player,
                    const shared_ptr<Player>& neutralPlayer,
                    const shared_ptr<Territory>& targetTerritory):
-                   player(player), neutralPlayer(neutralPlayer), targetTerritory(targetTerritory) {}
+                   Order(), player(player), neutralPlayer(neutralPlayer), targetTerritory(targetTerritory) {}
 Blockade::Blockade(const Blockade& blockade):Order(blockade) {
     this->player = blockade.player;
     this->neutralPlayer = blockade.neutralPlayer;
@@ -516,12 +519,11 @@ void Blockade::setTargetTerritory(const shared_ptr<Territory> &targetTerritory) 
 }
 
 // Airlift
-Airlift::Airlift():Order() {}
 Airlift::Airlift(const shared_ptr<Player>& player,
                  const shared_ptr<Territory>& sourceTerritory,
                  const shared_ptr<Territory>& targetTerritory,
                  int airliftArmies):
-                 player(player), sourceTerritory(sourceTerritory),
+                 Order(), player(player), sourceTerritory(sourceTerritory),
                  targetTerritory(targetTerritory), airliftArmies(airliftArmies) {}
 Airlift::Airlift(const Airlift& airlift):Order(airlift) {
     this->player = airlift.player;
@@ -637,9 +639,8 @@ void Airlift::setAirliftArmies(int airliftArmies) {
 }
 
 // Negotiate
-Negotiate::Negotiate():Order() {}
 Negotiate::Negotiate(shared_ptr<Player> &issuer, shared_ptr<Player> &targetPlayer):
-    issuer(issuer), targetPlayer(targetPlayer) {}
+    Order(), issuer(issuer), targetPlayer(targetPlayer) {}
 Negotiate::Negotiate(const Negotiate& negotiate):Order(negotiate) {
     this->issuer = negotiate.issuer;
     this->targetPlayer = negotiate.targetPlayer;

--- a/Orders.cpp
+++ b/Orders.cpp
@@ -176,7 +176,8 @@ ostream& operator<<(ostream& os, const Advance& advance) {
  * 1) the source territory belongs to the player issuing the order
  * 2) the target territory is adjacent to the source territory
  * 3) the player issuing the order has enough armies to advance
- * @return
+ * 4) the owner of the target territory is not in the issuing player's negotiatedPlayers
+ * @return whether the order is valid or not
  */
 bool Advance::validate()  {
     if (*sourceTerritory->getPlayerInPossession() != player->getName()) {
@@ -188,6 +189,12 @@ bool Advance::validate()  {
         // player doesn't have enough armies on the source territory
         return false;
     }
+
+    if (this->player->isInNegotiatedPlayers(*targetTerritory->getPlayerInPossession())) {
+        // can't attack a player in a negotiation agreement
+        return false;
+    }
+
     return true;
 }
 
@@ -365,6 +372,11 @@ bool Bomb::validate()  {
     }
 
     // TODO: check adjacency to any player-owned territory
+
+    if (this->player->isInNegotiatedPlayers(*targetTerritory->getPlayerInPossession())) {
+        // can't attack a player in a negotiation agreement
+        return false;
+    }
 
     return true;
 }
@@ -669,7 +681,6 @@ bool Negotiate::validate()  {
  * Prevents attacks between the two players.
  * This method specifically adds each player to their own negotiatedPlayers vector.
  * The attack orders will not attack players in players' negotiatedPlayers vector.
- * TODO: prevent attacks in other orders
  */
 void Negotiate::execute() {
     // status report

--- a/Orders.cpp
+++ b/Orders.cpp
@@ -476,14 +476,14 @@ void Blockade::execute() {
     cout << "Trying to blockade the territory:" << endl;
     cout << *this->targetTerritory;
     if (validate()) {
+        // transfer ownership to the Neutral player
+        this->player->removeTerritory(targetTerritory, neutralPlayer);
+
         // double the number of armies on the territory
         int targetArmies = *this->targetTerritory->getArmyCnt();
         targetArmies = targetArmies * 2;
         auto newTargetArmiesPtr = make_unique<int>(targetArmies);
         this->targetTerritory->setArmyCnt(newTargetArmiesPtr);
-
-        // transfer ownership to the Neutral player
-        this->player->removeTerritory(targetTerritory, neutralPlayer);
 
         // update report
         cout << "Successfully blockaded the territory:" << endl;

--- a/Orders.cpp
+++ b/Orders.cpp
@@ -683,7 +683,7 @@ void Negotiate::execute() {
         // update report
         cout << "Negotiation succeeded." << endl;
     } else {
-        cout << "Invalid negotiate order. Could not execute.";
+        cout << "Invalid negotiate order. Could not execute." << endl;
     }
 }
 

--- a/Orders.cpp
+++ b/Orders.cpp
@@ -665,9 +665,26 @@ bool Negotiate::validate()  {
     return true;
 }
 
+/**
+ * Prevents attacks between the two players.
+ * This method specifically adds each player to their own negotiatedPlayers vector.
+ * The attack orders will not attack players in players' negotiatedPlayers vector.
+ * TODO: prevent attacks in other orders
+ */
 void Negotiate::execute() {
-    // logic to be implemented in later assignments
-    cout << "negotiate order executed\n";
+    // status report
+    cout << "Trying to negotiate between " << issuer->getName()
+        << " and " << targetPlayer->getName() << endl;
+    if (validate()) {
+        // add each player to each other's negotiatedPlayers
+        this->issuer->addNegotiatedPlayer(targetPlayer);
+        this->targetPlayer->addNegotiatedPlayer(issuer);
+
+        // update report
+        cout << "Negotiation succeeded." << endl;
+    } else {
+        cout << "Invalid negotiate order. Could not execute.";
+    }
 }
 
 const shared_ptr<Player> &Negotiate::getIssuer() const {

--- a/Orders.h
+++ b/Orders.h
@@ -39,7 +39,6 @@ private:
 // deploy(), advance(), bomb(), blockade(), airlift(), negotiate()
 class Deploy : public Order {
 public:
-    Deploy();
     Deploy(const shared_ptr<Player>& player,
            const shared_ptr<Territory>& targetTerritory,
            int deployedArmies);
@@ -67,7 +66,6 @@ private:
 
 class Advance : public Order {
 public:
-    Advance();
     Advance(const shared_ptr<Player>& player,
             const shared_ptr<Territory>& sourceTerritory,
             const shared_ptr<Territory>& targetTerritory,
@@ -102,7 +100,6 @@ private:
 
 class Bomb : public Order {
 public:
-    Bomb();
     Bomb(const shared_ptr<Player>& player,
          const shared_ptr<Territory>& targetTerritory);
     Bomb(const Bomb& bomb);
@@ -125,7 +122,6 @@ private:
 
 class Blockade : public Order {
 public:
-    Blockade();
     Blockade(const shared_ptr<Player>& player,
              const shared_ptr<Player>& neutralPlayer,
              const shared_ptr<Territory>& targetTerritory);
@@ -153,7 +149,6 @@ private:
 
 class Airlift : public Order {
 public:
-    Airlift();
     Airlift(const shared_ptr<Player>& player,
             const shared_ptr<Territory>& sourceTerritory,
             const shared_ptr<Territory>& targetTerritory,
@@ -186,7 +181,6 @@ private:
 
 class Negotiate : public Order {
 public:
-    Negotiate();
     Negotiate(shared_ptr<Player> &issuer, shared_ptr<Player> &targetPlayer);
     Negotiate(const Negotiate& negotiate);
     Negotiate& operator=(const Negotiate& negotiate);

--- a/Orders.h
+++ b/Orders.h
@@ -187,12 +187,23 @@ private:
 class Negotiate : public Order {
 public:
     Negotiate();
+    Negotiate(shared_ptr<Player> &issuer, shared_ptr<Player> &targetPlayer);
     Negotiate(const Negotiate& negotiate);
     Negotiate& operator=(const Negotiate& negotiate);
     friend ostream& operator<<(ostream& os, const Negotiate& negotiate);
 
     bool validate() override;
     void execute() override;
+
+    const shared_ptr<Player> &getIssuer() const;
+    void setIssuer(const shared_ptr<Player> &issuer);
+
+    const shared_ptr<Player> &getTargetPlayer() const;
+    void setTargetPlayer(const shared_ptr<Player> &targetPlayer);
+
+private:
+    shared_ptr<Player> issuer; // player issuing the order
+    shared_ptr<Player> targetPlayer;
 };
 
 class OrdersList {

--- a/Orders.h
+++ b/Orders.h
@@ -238,5 +238,6 @@ void advanceDemo();
 void airliftDemo();
 void bombDemo();
 void blockadeDemo();
+void negotiateDemo();
 
 #endif // ORDERS_H

--- a/OrdersDriver.cpp
+++ b/OrdersDriver.cpp
@@ -50,6 +50,7 @@ void ordersDemo2() {
     airliftDemo();
     bombDemo();
     blockadeDemo();
+    negotiateDemo();
 }
 
 void deployDemo() {
@@ -224,4 +225,28 @@ void blockadeDemo() {
     // blockade not owned territory
     cout << "---- Blockade not owned territory ----" << endl;
     blockadeOrder->execute(); // blockading again, but now it's owned by the neutral player
+}
+
+void negotiateDemo() {
+    // -- NEGOTIATE TESTS --
+    cout << "\n\n-- NEGOTIATE TESTS --" << endl;
+
+    // prepare player
+    auto testPlayerNegotiate1 = make_shared<Player>();
+    auto testPlayerNegotiate2 = make_shared<Player>();
+
+    // Negotiate with self
+    cout << "---- Negotiate with self ----" << endl;
+    auto negotiateSelf = make_unique<Negotiate>(testPlayerNegotiate1, testPlayerNegotiate1);
+    cout << *testPlayerNegotiate1 << endl;
+    negotiateSelf->execute();
+
+    // Negotiate with other
+    cout << "\n---- Negotiate with other ----" << endl;
+    auto negotiateOther = make_unique<Negotiate>(testPlayerNegotiate1, testPlayerNegotiate2);
+    cout << *testPlayerNegotiate1 << endl;
+    cout << *testPlayerNegotiate2 << endl;
+    negotiateOther->execute();
+    cout << *testPlayerNegotiate1 << endl << endl;
+    cout << *testPlayerNegotiate2 << endl;
 }

--- a/OrdersDriver.cpp
+++ b/OrdersDriver.cpp
@@ -231,9 +231,16 @@ void negotiateDemo() {
     // -- NEGOTIATE TESTS --
     cout << "\n\n-- NEGOTIATE TESTS --" << endl;
 
+    // prepare territories
+    auto testTerritory1 = make_shared<Territory>(0, "testTerritory1", 0, "test", 3);
+    auto testTerritory2 = make_shared<Territory>(0, "testTerritory2", 0, "test", 2);
+
     // prepare player
     auto testPlayerNegotiate1 = make_shared<Player>();
     auto testPlayerNegotiate2 = make_shared<Player>();
+
+    testPlayerNegotiate1->addTerritory(testTerritory1);
+    testPlayerNegotiate2->addTerritory(testTerritory2);
 
     // Negotiate with self
     cout << "---- Negotiate with self ----" << endl;
@@ -249,4 +256,9 @@ void negotiateDemo() {
     negotiateOther->execute();
     cout << *testPlayerNegotiate1 << endl << endl;
     cout << *testPlayerNegotiate2 << endl;
+
+    // Try to attack negotiated player
+    cout << "\n---- Attacking negotiated player ----" << endl;
+    auto advance = make_unique<Advance>(testPlayerNegotiate1, testTerritory1, testTerritory2, 2);
+    advance->execute();
 }

--- a/OrdersDriver.cpp
+++ b/OrdersDriver.cpp
@@ -5,43 +5,43 @@
 using namespace std;
 
 void ordersDemo1() {
-    // create order of every kind
-    auto testDeploy = make_shared<Deploy>();
-    auto testAdvance = make_shared<Advance>();
-    auto testBomb = make_shared<Bomb>();
-    auto testBlockade = make_shared<Blockade>();
-    auto testAirlift = make_shared<Airlift>();
-    auto testNegotiate = make_shared<Negotiate>();
-
-    // create a list of orders
-    auto testOrdersList = make_unique<OrdersList>();
-    testOrdersList->add(testDeploy);
-    testOrdersList->add(testAdvance);
-    testOrdersList->add(testBomb);
-    testOrdersList->add(testBlockade);
-    testOrdersList->add(testAirlift);
-    testOrdersList->add(testNegotiate);
-
-    cout << "\n== OrdersList Stream Insertion Operator ==\n" << *testOrdersList << endl;
-
-    for (const auto& order : *testOrdersList->getOrderList()) {
-        // every order subclass has validate()
-        order->validate();
-        // every order subclass has execute()
-        order->execute();
-    }
-
-    // OrdersList has remove()
-    testOrdersList->remove(3); // remove bomb
-    cout << "\n== OrdersLost::remove() ==\n[removing order with orderID 3 (bomb)]\n" << *testOrdersList << endl;
-
-    //OrdersList has move()
-    cout << "\n== OrdersLost::move() ==\n[move(\"up\", 2) - swapping advance (2) and deploy (1)]\n";
-    testOrdersList->move("up", 2); // swap advance and deploy
-    cout << *testOrdersList << endl;
-    cout << "[move(\"down\", 5) - swapping airlift (5) and negotiate (6)]\n";
-    testOrdersList->move("down", 5);
-    cout << *testOrdersList << endl;
+//    // create order of every kind
+//    auto testDeploy = make_shared<Deploy>();
+//    auto testAdvance = make_shared<Advance>();
+//    auto testBomb = make_shared<Bomb>();
+//    auto testBlockade = make_shared<Blockade>();
+//    auto testAirlift = make_shared<Airlift>();
+//    auto testNegotiate = make_shared<Negotiate>();
+//
+//    // create a list of orders
+//    auto testOrdersList = make_unique<OrdersList>();
+//    testOrdersList->add(testDeploy);
+//    testOrdersList->add(testAdvance);
+//    testOrdersList->add(testBomb);
+//    testOrdersList->add(testBlockade);
+//    testOrdersList->add(testAirlift);
+//    testOrdersList->add(testNegotiate);
+//
+//    cout << "\n== OrdersList Stream Insertion Operator ==\n" << *testOrdersList << endl;
+//
+//    for (const auto& order : *testOrdersList->getOrderList()) {
+//        // every order subclass has validate()
+//        order->validate();
+//        // every order subclass has execute()
+//        order->execute();
+//    }
+//
+//    // OrdersList has remove()
+//    testOrdersList->remove(3); // remove bomb
+//    cout << "\n== OrdersLost::remove() ==\n[removing order with orderID 3 (bomb)]\n" << *testOrdersList << endl;
+//
+//    //OrdersList has move()
+//    cout << "\n== OrdersLost::move() ==\n[move(\"up\", 2) - swapping advance (2) and deploy (1)]\n";
+//    testOrdersList->move("up", 2); // swap advance and deploy
+//    cout << *testOrdersList << endl;
+//    cout << "[move(\"down\", 5) - swapping airlift (5) and negotiate (6)]\n";
+//    testOrdersList->move("down", 5);
+//    cout << *testOrdersList << endl;
 }
 
 void ordersDemo2() {

--- a/Player.cpp
+++ b/Player.cpp
@@ -237,6 +237,17 @@ void Player::removeTerritory(const shared_ptr<Territory> &territory, const share
     territory->setPlayerInPossession(newOwnerNamePtr);
 }
 
+/**
+ * Clean up territories to remove territories not owned by the player anymore.
+ */
+void Player::updateTerritories() {
+    for (const auto& territory : *this->territories) {
+        if (*territory->getPlayerInPossession() != this->name) {
+            this->removeTerritory(territory);
+        }
+    }
+}
+
 void Player::addNegotiatedPlayer(const shared_ptr<Player>& player) {
     this->negotiatedPlayers->push_back(player);
 }

--- a/Player.cpp
+++ b/Player.cpp
@@ -239,4 +239,12 @@ void Player::clearNegotiatedPlayers() {
     this->negotiatedPlayers->clear();
 }
 
+bool Player::isInNegotiatedPlayers(string playerName) {
+    return any_of(this->negotiatedPlayers->begin(),
+                  this->negotiatedPlayers->end(),
+                  [&](const auto& player) {
+        return player->getName() == playerName;
+    });
+}
+
 

--- a/Player.cpp
+++ b/Player.cpp
@@ -88,6 +88,12 @@ ostream& operator<<(ostream& os, const Player& player) {
 
     os << "Hand: " << *player.cardHand << endl;
     os << "Orders: " << *player.ordersList << endl;
+    os << "negotiatedPlayers:" << endl;
+    if (player.negotiatedPlayers) {
+        for (const auto& p : *player.negotiatedPlayers) {
+            os << "    " << p->getName();
+        }
+    }
 
     return os;
 }

--- a/Player.cpp
+++ b/Player.cpp
@@ -210,17 +210,23 @@ void Player::addTerritory(const shared_ptr<Territory>& territory) {
     // change player in possession
     auto playerNamePtr = make_unique<string>(this->name);
     territory->setPlayerInPossession(playerNamePtr);
+
+    // update army count
+    this->armyCount += *territory->getArmyCnt();
 }
 
 void Player::removeTerritory(const shared_ptr<Territory>& territory) {
+    // find the territory
     auto iterator = find_if(this->territories->begin(), this->territories->end(),
                             [territory](const shared_ptr<Territory>& t) {
         return t->getId() == territory->getId();
     });
 
     if (iterator != this->territories->end()) {
-        // element is found
+        // territory is found, remove it
         this->territories->erase(iterator);
+        // update army count
+        this->armyCount -= *territory->getArmyCnt();
     }
 }
 

--- a/Player.cpp
+++ b/Player.cpp
@@ -12,7 +12,8 @@ Player::Player():
     reinforcementPool(3),
     territories(make_unique<vector<shared_ptr<Territory>>>()),
     cardHand(make_unique<Hand>()),
-    ordersList(make_unique<OrdersList>()) {}
+    ordersList(make_unique<OrdersList>()),
+    negotiatedPlayers(make_unique<vector<shared_ptr<Player>>>()){}
 
 // parameterized constructors (for testing)
 Player::Player(const vector<shared_ptr<Territory>>& territories):
@@ -21,7 +22,8 @@ Player::Player(const vector<shared_ptr<Territory>>& territories):
     reinforcementPool(3),
     territories(make_unique<vector<shared_ptr<Territory>>>(territories)),
     cardHand(make_unique<Hand>()),
-    ordersList(make_unique<OrdersList>()) {
+    ordersList(make_unique<OrdersList>()),
+    negotiatedPlayers(make_unique<vector<shared_ptr<Player>>>()){
     setTerritories(this->territories);
 }
 
@@ -31,7 +33,8 @@ Player::Player(int armyCount, int reinforcementPool, const vector<shared_ptr<Ter
     reinforcementPool(reinforcementPool),
     territories(make_unique<vector<shared_ptr<Territory>>>(territories)),
     cardHand(make_unique<Hand>()),
-    ordersList(make_unique<OrdersList>()) {
+    ordersList(make_unique<OrdersList>()),
+    negotiatedPlayers(make_unique<vector<shared_ptr<Player>>>()){
     setTerritories(this->territories);
 }
 
@@ -41,7 +44,8 @@ Player::Player(const Player& player):
     reinforcementPool(player.reinforcementPool),
     territories(make_unique<vector<shared_ptr<Territory>>>()),
     cardHand(make_unique<Hand>(*player.cardHand)),
-    ordersList(make_unique<OrdersList>(*player.ordersList)) {
+    ordersList(make_unique<OrdersList>(*player.ordersList)),
+    negotiatedPlayers(make_unique<vector<shared_ptr<Player>>>()){
     for (const auto& t: *player.territories) {
         this->territories->push_back(t);
     }
@@ -62,6 +66,7 @@ Player& Player::operator=(const Player& player) {
         }
         this->cardHand = make_unique<Hand>(*player.cardHand);
         this->ordersList = make_unique<OrdersList>(*player.ordersList);
+        this->setNegotiatedPlayers(player.negotiatedPlayers);
         return *this;
     }
 }
@@ -138,6 +143,16 @@ void Player::setOrdersList(unique_ptr<OrdersList> &ordersList) {
     Player::ordersList = std::move(ordersList);
 }
 
+const unique_ptr<vector<shared_ptr<Player>>> &Player::getNegotiatedPlayers() const {
+    return negotiatedPlayers;
+}
+
+void Player::setNegotiatedPlayers(const unique_ptr<vector<shared_ptr<Player>>> &negotiatedPlayers) {
+    for (const auto& player : *negotiatedPlayers) {
+        this->negotiatedPlayers->push_back(player);
+    }
+}
+
 // destructor
 Player::~Player() = default; // deletion of data members handled by smart pointers already
 
@@ -209,3 +224,5 @@ void Player::removeTerritory(const shared_ptr<Territory> &territory, const share
     auto newOwnerNamePtr = make_unique<string>(newOwner->getName());
     territory->setPlayerInPossession(newOwnerNamePtr);
 }
+
+

--- a/Player.cpp
+++ b/Player.cpp
@@ -253,4 +253,13 @@ bool Player::isInNegotiatedPlayers(string playerName) {
     });
 }
 
+int Player::updateArmyCount() {
+    int newArmyCount = 0;
+    for (const auto& territory : *this->territories) {
+        newArmyCount += *territory->getArmyCnt();
+    }
+    this->armyCount = newArmyCount;
+    return newArmyCount;
+}
+
 

--- a/Player.cpp
+++ b/Player.cpp
@@ -225,4 +225,12 @@ void Player::removeTerritory(const shared_ptr<Territory> &territory, const share
     territory->setPlayerInPossession(newOwnerNamePtr);
 }
 
+void Player::addNegotiatedPlayer(const shared_ptr<Player>& player) {
+    this->negotiatedPlayers->push_back(player);
+}
+
+void Player::clearNegotiatedPlayers() {
+    this->negotiatedPlayers->clear();
+}
+
 

--- a/Player.cpp
+++ b/Player.cpp
@@ -199,8 +199,8 @@ unique_ptr<vector<shared_ptr<Territory>>> Player::toAttack() {
  */
 void Player::issueOrder() {
     // TODO: not arbitrary anymore
-    auto testOrder = make_shared<Deploy>();
-    ordersList->add(testOrder);
+//    auto testOrder = make_shared<Deploy>();
+//    ordersList->add(testOrder);
 }
 
 void Player::addTerritory(const shared_ptr<Territory>& territory) {

--- a/Player.h
+++ b/Player.h
@@ -37,6 +37,9 @@ public:
     void removeTerritory(const shared_ptr<Territory>& territory);
     void removeTerritory(const shared_ptr<Territory>& territory, const shared_ptr<Player>& newOwner);
 
+    void addNegotiatedPlayer(const shared_ptr<Player>& player);
+    void clearNegotiatedPlayers();
+
     // getters and setters
     const string &getName() const;
 
@@ -56,7 +59,6 @@ public:
     void setOrdersList(unique_ptr<OrdersList> &ordersList);
 
     const unique_ptr<vector<shared_ptr<Player>>> &getNegotiatedPlayers() const;
-
     void setNegotiatedPlayers(const unique_ptr<vector<shared_ptr<Player>>> &negotiatedPlayers);
 
 private:

--- a/Player.h
+++ b/Player.h
@@ -36,6 +36,7 @@ public:
     void addTerritory(const shared_ptr<Territory>& territory);
     void removeTerritory(const shared_ptr<Territory>& territory);
     void removeTerritory(const shared_ptr<Territory>& territory, const shared_ptr<Player>& newOwner);
+    void updateTerritories();
 
     void addNegotiatedPlayer(const shared_ptr<Player>& player);
     void clearNegotiatedPlayers();

--- a/Player.h
+++ b/Player.h
@@ -41,6 +41,8 @@ public:
     void clearNegotiatedPlayers();
     bool isInNegotiatedPlayers(string playerName);
 
+    int updateArmyCount();
+
     // getters and setters
     const string &getName() const;
 

--- a/Player.h
+++ b/Player.h
@@ -55,6 +55,10 @@ public:
     const unique_ptr<OrdersList> &getOrdersList() const;
     void setOrdersList(unique_ptr<OrdersList> &ordersList);
 
+    const unique_ptr<vector<shared_ptr<Player>>> &getNegotiatedPlayers() const;
+
+    void setNegotiatedPlayers(const unique_ptr<vector<shared_ptr<Player>>> &negotiatedPlayers);
+
 private:
     static int nextID;
     const string name;
@@ -66,6 +70,8 @@ private:
     unique_ptr<vector<shared_ptr<Territory>>> territories;
     // player has list of orders
     unique_ptr<OrdersList> ordersList;
+    // for the negotiation order
+    unique_ptr<vector<shared_ptr<Player>>> negotiatedPlayers;
 };
 
 void playerDemo1();

--- a/Player.h
+++ b/Player.h
@@ -39,6 +39,7 @@ public:
 
     void addNegotiatedPlayer(const shared_ptr<Player>& player);
     void clearNegotiatedPlayers();
+    bool isInNegotiatedPlayers(string playerName);
 
     // getters and setters
     const string &getName() const;


### PR DESCRIPTION
Missing:
* ensure that the negotiate order can only be created by playing the diplomacy card
* after every turn (will need to add code to game engine)
    1) update army count
    2) update reinforcement pool
    3) update territories
    4) clear negotiated players