### PR TITLE
Part 4 - modifications for the advance order requirements

### DIFF
--- a/Cards.cpp
+++ b/Cards.cpp
@@ -227,3 +227,7 @@ void Hand::clearPlayedCards()
 	playCards.clear();
 	cout << "\n Play Cards are Cleaned." << endl;
 }
+
+void Hand::addCardtoHand(Card *card) {
+    handCards.push_back(card);
+}

--- a/Cards.h
+++ b/Cards.h
@@ -62,6 +62,9 @@ public:
 	vector<Card*>* getPlayCards();
 	void deletePlayedCardsFromHand(Card* r_card);
 	void clearPlayedCards();
+
+    void addCardtoHand(Card* card);
+
 	// stream insertion operator
 	friend ostream& operator<<(ostream& os, const Hand& hand);
 

--- a/Orders.cpp
+++ b/Orders.cpp
@@ -234,7 +234,7 @@ void Advance::execute() {
  * 3) if all defending armies are eliminated, the attacker captures the territory
  * the surviving attacking units occupy the territory and ownership changes
  * 4) a player receives a card at the end of his turn if they successfully conquered at least one territory
- * during their turn TODO: discuss how to implement this (4)
+ * during their turn TODO: get game engine to call Player::update() for all players after every turn
  */
 void Advance::attack() {
     int sourceArmies = *this->sourceTerritory->getArmyCnt();

--- a/Orders.cpp
+++ b/Orders.cpp
@@ -289,17 +289,13 @@ void Advance::attack() {
         // new army count is now the surviving attackers
         auto newArmyCountPtr = make_unique<int>(attackingArmies);
         targetTerritory->setArmyCnt(newArmyCountPtr);
+        // note that the player has successfully conquered at least one territory this turn
+        this->player->setHasConqueredTerritory(true);
     } else {
         // defenders won, no ownership change, update surviving defending armies
         auto newArmyCountPtr = make_unique<int>(defendingArmies);
         targetTerritory->setArmyCnt(newArmyCountPtr);
     }
-
-    // TODO: after every turn
-    //  1) update army count
-    //  2) update reinforcement pool
-    //  3) update territories
-    //  4) clear negotiated players
 }
 
 // getters and setters

--- a/OrdersDriver.cpp
+++ b/OrdersDriver.cpp
@@ -117,7 +117,12 @@ void advanceDemo() {
                                                         3);
     cout << *testPlayerAdvance << endl;
     advanceToEnemyTerritory->execute();
-    cout << *testPlayerAdvance << endl;
+
+    cout << "Simulating end of turn . . ." << endl;
+    shared_ptr<Deck> deck = make_shared<Deck>();
+    deck->MakeDeck();
+    testPlayerAdvance->update(deck);
+    cout << "Player status: " << endl << *testPlayerAdvance << endl;
 }
 
 void airliftDemo() {

--- a/Player.cpp
+++ b/Player.cpp
@@ -287,6 +287,20 @@ int Player::updateArmyCount() {
     return newArmyCount;
 }
 
+/**
+ * Checks if the player has conquered any territory this turn, and if so
+ * draws a card from the deck and adds it to the player's hand of cards.
+ *
+ * Meant to be called at the end of every turn.
+ * @param deck shared pointer to the deck of cards used during the game
+ */
+void Player::drawIfHasConquered(const shared_ptr<Deck> &deck) {
+    if (hasConqueredTerritory) {
+        Card* card = deck->draw();
+        this->cardHand->addCardtoHand(card);
+    }
+}
+
 
 
 

--- a/Player.cpp
+++ b/Player.cpp
@@ -99,7 +99,7 @@ ostream& operator<<(ostream& os, const Player& player) {
             os << "    " << p->getName();
         }
     }
-    os << "hasConqueredTerritory: " << player.hasConqueredTerritory;
+    os << "hasConqueredTerritory: " << player.hasConqueredTerritory << endl;
 
     return os;
 }

--- a/Player.cpp
+++ b/Player.cpp
@@ -13,7 +13,8 @@ Player::Player():
     territories(make_unique<vector<shared_ptr<Territory>>>()),
     cardHand(make_unique<Hand>()),
     ordersList(make_unique<OrdersList>()),
-    negotiatedPlayers(make_unique<vector<shared_ptr<Player>>>()){}
+    negotiatedPlayers(make_unique<vector<shared_ptr<Player>>>()),
+    hasConqueredTerritory(false) {}
 
 // parameterized constructors (for testing)
 Player::Player(const vector<shared_ptr<Territory>>& territories):
@@ -23,7 +24,8 @@ Player::Player(const vector<shared_ptr<Territory>>& territories):
     territories(make_unique<vector<shared_ptr<Territory>>>(territories)),
     cardHand(make_unique<Hand>()),
     ordersList(make_unique<OrdersList>()),
-    negotiatedPlayers(make_unique<vector<shared_ptr<Player>>>()){
+    negotiatedPlayers(make_unique<vector<shared_ptr<Player>>>()),
+    hasConqueredTerritory(false) {
     setTerritories(this->territories);
 }
 
@@ -34,7 +36,8 @@ Player::Player(int armyCount, int reinforcementPool, const vector<shared_ptr<Ter
     territories(make_unique<vector<shared_ptr<Territory>>>(territories)),
     cardHand(make_unique<Hand>()),
     ordersList(make_unique<OrdersList>()),
-    negotiatedPlayers(make_unique<vector<shared_ptr<Player>>>()){
+    negotiatedPlayers(make_unique<vector<shared_ptr<Player>>>()),
+    hasConqueredTerritory(false) {
     setTerritories(this->territories);
 }
 
@@ -45,7 +48,8 @@ Player::Player(const Player& player):
     territories(make_unique<vector<shared_ptr<Territory>>>()),
     cardHand(make_unique<Hand>(*player.cardHand)),
     ordersList(make_unique<OrdersList>(*player.ordersList)),
-    negotiatedPlayers(make_unique<vector<shared_ptr<Player>>>()){
+    negotiatedPlayers(make_unique<vector<shared_ptr<Player>>>()),
+    hasConqueredTerritory(player.hasConqueredTerritory) {
     for (const auto& t: *player.territories) {
         this->territories->push_back(t);
     }
@@ -67,6 +71,7 @@ Player& Player::operator=(const Player& player) {
         this->cardHand = make_unique<Hand>(*player.cardHand);
         this->ordersList = make_unique<OrdersList>(*player.ordersList);
         this->setNegotiatedPlayers(player.negotiatedPlayers);
+        this->hasConqueredTerritory = player.hasConqueredTerritory;
         return *this;
     }
 }
@@ -94,6 +99,7 @@ ostream& operator<<(ostream& os, const Player& player) {
             os << "    " << p->getName();
         }
     }
+    os << "hasConqueredTerritory: " << player.hasConqueredTerritory;
 
     return os;
 }
@@ -157,6 +163,14 @@ void Player::setNegotiatedPlayers(const unique_ptr<vector<shared_ptr<Player>>> &
     for (const auto& player : *negotiatedPlayers) {
         this->negotiatedPlayers->push_back(player);
     }
+}
+
+bool Player::getHasConqueredTerritory() const {
+    return hasConqueredTerritory;
+}
+
+void Player::setHasConqueredTerritory(bool hasConqueredTerritory) {
+    Player::hasConqueredTerritory = hasConqueredTerritory;
 }
 
 // destructor
@@ -272,5 +286,8 @@ int Player::updateArmyCount() {
     this->armyCount = newArmyCount;
     return newArmyCount;
 }
+
+
+
 
 

--- a/Player.cpp
+++ b/Player.cpp
@@ -301,6 +301,31 @@ void Player::drawIfHasConquered(const shared_ptr<Deck> &deck) {
     }
 }
 
+/**
+ * Updates all the player data members that need to be updated after every turn
+ * and executes any additional actions that need to be done every turn.
+ *
+ * Updates to be done every turn:
+ * 1) update army count
+ * 2) update reinforcement pool
+ * 3) update territories
+ * 4) clear negotiated players
+ * 5) draw if hasConqueredTerritory
+ * 6) clear hasConqueredTerritory
+ *
+ * This method is meant to be called at the end of every turn on every player.
+ *
+ * @param deck shared pointer to the deck of cards used during the game
+ */
+void Player::update(const shared_ptr<Deck>& deck) {
+    this->updateArmyCount();
+    this->reinforcementPool = this->armyCount;
+    this->updateTerritories();
+    this->clearNegotiatedPlayers();
+    this->drawIfHasConquered(deck);
+    this->hasConqueredTerritory = false;
+}
+
 
 
 

--- a/Player.h
+++ b/Player.h
@@ -65,11 +65,15 @@ public:
     const unique_ptr<vector<shared_ptr<Player>>> &getNegotiatedPlayers() const;
     void setNegotiatedPlayers(const unique_ptr<vector<shared_ptr<Player>>> &negotiatedPlayers);
 
+    bool getHasConqueredTerritory() const;
+    void setHasConqueredTerritory(bool hasConqueredTerritory);
+
 private:
     static int nextID;
     const string name;
     int armyCount; // total army count available to the player
     int reinforcementPool; // armies the player can use every turn, decreases as the player uses them, replenishes later
+    bool hasConqueredTerritory; // true if the player has conquered a territory anytime during the current turn
     // player owns a hand of Warzone cards
     unique_ptr<Hand> cardHand;
     // player owns collection of territories

--- a/Player.h
+++ b/Player.h
@@ -44,6 +44,8 @@ public:
 
     int updateArmyCount();
 
+    void drawIfHasConquered(const shared_ptr<Deck>& deck);
+
     // getters and setters
     const string &getName() const;
 

--- a/Player.h
+++ b/Player.h
@@ -46,6 +46,8 @@ public:
 
     void drawIfHasConquered(const shared_ptr<Deck>& deck);
 
+    void update(const shared_ptr<Deck>& deck);
+
     // getters and setters
     const string &getName() const;
 


### PR DESCRIPTION
This update enables the "player draws a card if the player has conquered at least one territory this turn" criteria for the advance order.

It also adds a an update() method to be called on each player after every turn that takes care of player maintenance.